### PR TITLE
added delay to selectDisplay() to prevent ghosting

### DIFF
--- a/Firmware-ESP32/display.c
+++ b/Firmware-ESP32/display.c
@@ -234,6 +234,10 @@ void selectDisplay(int display, byte number1, byte number2)
   // so that the full digit comes up simultanously
   // (although who is going to be able to detect a couple clk cycles?)
   resetSegments();
+  
+  // sit here and wait a while to ensure that the segment data pins fall to low
+  delay(DELAYTIME);
+  
   setSegment1(number1);
   setSegment2(number2);
 


### PR DESCRIPTION
## Problem:
For me, each digit has a significant "ghost" behind it. I'm sure this has something to do with the specific hardware I'm using as I see no evidence of ghosting in the images in README.md

![image](https://user-images.githubusercontent.com/20545489/169210583-c7e133dc-618d-451b-ad19-3f57b9ea389e.png)
You can see here that digit #0 (indexed from the left) is showing "1", but it's also showing a ghosted version of digit #9 resulting in this mangled half "1" - half "2" digit. This applies for every digit with #7 being ghosted on #9, #8 being ghosted on #10 and so on


## Explanation:
The lifecycle of a LCD update is as follows

```
for each display 1-5:
  turn PWM for displays 1-5 off
  set all data pins (a1 to g2) to low
  set the required data pins for the specified digits to high
  turn PWM for the specified display on
```

This issue occurs because the data pins haven't fully fallen back down to low by the time we turn the PWM on, resulting in a ghosted display.

## Solution:
If we add a small delay between setting the data pins and turning the PWM on for the display, we can ensure that all pins have fallen back down to low by the time the display comes on.

I've tested this on my display and it works great! I don't anticipate this causing any problems (ie flickering) because this only adds 5ms delay per cycle and the loop still runs at about 200hz which is plenty fast for persistence of vision to work it's magic.